### PR TITLE
feat: add debug option for environment validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,16 @@ docker compose up
 
 This takes care of setting up everything including MongoDB, Minio etc.
 
-To inspect your configuration before starting the full stack, run the
-`validate` service in debug mode. This dumps all environment variables and
-stops before other services are started:
+To inspect your configuration before starting the full stack, set
+`DEBUG_VALIDATE=1`. The `validate` service prints the required environment
+variables and exits before other services start:
 
 ```bash
-DEBUG_VALIDATE=1 docker compose up validate
+DEBUG_VALIDATE=1 docker compose up
 ```
 
-Unset `DEBUG_VALIDATE` to run the full stack normally.
+Check the `validate` container logs to see the output. Unset `DEBUG_VALIDATE`
+to run the full stack normally.
 
 ## TODO Self-hosting
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ docker compose up
 
 This takes care of setting up everything including MongoDB, Minio etc.
 
+To inspect your configuration before starting the full stack, run the
+`validate` service in debug mode. This dumps all environment variables and
+stops before other services are started:
+
+```bash
+DEBUG_VALIDATE=1 docker compose up validate
+```
+
+Unset `DEBUG_VALIDATE` to run the full stack normally.
+
 ## TODO Self-hosting
 
 **Note: Self-hosting the Notesnook Sync Server is now possible, but without support. Documentation will be provided at a later date. We are working to enable full on-premise self-hosting, so stay tuned!**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,6 @@ services:
     command:
       - -c
       - |
-        # If DEBUG_VALIDATE is set, print all environment variables and exit
-        if [ "$${DEBUG_VALIDATE:-}" = "1" ]; then
-          echo "DEBUG_VALIDATE enabled. Dumping environment variables:"
-          env
-          exit 1
-        fi
-
         # List of required environment variables
         required_vars=(
           "INSTANCE_NAME"
@@ -41,6 +34,15 @@ services:
           "MONOGRAPH_PUBLIC_URL"
           "ATTACHMENTS_SERVER_PUBLIC_URL"
         )
+
+        # If DEBUG_VALIDATE is set, dump required variables and exit
+        if [ "$${DEBUG_VALIDATE:-}" = "1" ]; then
+          echo "DEBUG_VALIDATE enabled. Dumping required environment variables:"
+          for var in "$${required_vars[@]}"; do
+            echo "$$var=$${!var}"
+          done
+          exit 1
+        fi
 
         # Check each required environment variable
         for var in "$${required_vars[@]}"; do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,13 @@ services:
     command:
       - -c
       - |
+        # If DEBUG_VALIDATE is set, print all environment variables and exit
+        if [ "$${DEBUG_VALIDATE:-}" = "1" ]; then
+          echo "DEBUG_VALIDATE enabled. Dumping environment variables:"
+          env
+          exit 1
+        fi
+
         # List of required environment variables
         required_vars=(
           "INSTANCE_NAME"


### PR DESCRIPTION
## Summary
- allow validate service to dump env variables and exit when DEBUG_VALIDATE=1
- document DEBUG_VALIDATE usage for docker compose

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a19a0225a483328d3a7e742db414f2