### PR TITLE
refactor: use script for env validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,42 +17,9 @@ services:
     image: vandot/alpine-bash
     entrypoint: /bin/bash
     env_file: *env-files
-    command:
-      - -c
-      - |
-        # List of required environment variables
-        required_vars=(
-          "INSTANCE_NAME"
-          "NOTESNOOK_API_SECRET"
-          "DISABLE_SIGNUPS"
-          "SMTP_USERNAME"
-          "SMTP_PASSWORD"
-          "SMTP_HOST"
-          "SMTP_PORT"
-          "AUTH_SERVER_PUBLIC_URL"
-          "NOTESNOOK_APP_PUBLIC_URL"
-          "MONOGRAPH_PUBLIC_URL"
-          "ATTACHMENTS_SERVER_PUBLIC_URL"
-        )
-
-        # If DEBUG_VALIDATE is set, dump required variables and exit
-        if [ "$${DEBUG_VALIDATE:-}" = "1" ]; then
-          echo "DEBUG_VALIDATE enabled. Dumping required environment variables:"
-          for var in "$${required_vars[@]}"; do
-            echo "$$var=$${!var}"
-          done
-          exit 1
-        fi
-
-        # Check each required environment variable
-        for var in "$${required_vars[@]}"; do
-          if [ -z "$${!var}" ]; then
-            echo "Error: Required environment variable $$var is not set."
-            exit 1
-          fi
-        done
-
-        echo "All required environment variables are set."
+    volumes:
+      - ./scripts/validate-env.sh:/validate-env.sh:ro
+    command: ["/validate-env.sh"]
     # Ensure the validate service runs first
     restart: "no"
 

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_vars=(
+  "INSTANCE_NAME"
+  "NOTESNOOK_API_SECRET"
+  "DISABLE_SIGNUPS"
+  "SMTP_USERNAME"
+  "SMTP_PASSWORD"
+  "SMTP_HOST"
+  "SMTP_PORT"
+  "AUTH_SERVER_PUBLIC_URL"
+  "NOTESNOOK_APP_PUBLIC_URL"
+  "MONOGRAPH_PUBLIC_URL"
+  "ATTACHMENTS_SERVER_PUBLIC_URL"
+)
+
+missing=()
+
+for var in "${required_vars[@]}"; do
+  value="${!var:-}"
+  if [ "${DEBUG_VALIDATE:-0}" = "1" ]; then
+    echo "$var=$value"
+  fi
+  if [ -z "$value" ]; then
+    missing+=("$var")
+  fi
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "Error: Required environment variables are not set: ${missing[*]}" >&2
+  exit 1
+fi
+
+echo "All required environment variables are set."


### PR DESCRIPTION
## Summary
- extract environment variable checks into `validate-env.sh`
- run the new script from the `validate` service in `docker-compose.yml`

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a035690c83329529b8057a25a32e