### PR TITLE
Enable development environment in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
       <<: *server-discovery
       MONGODB_CONNECTION_STRING: mongodb://notesnook-db:27017/identity?replSet=rs0
       MONGODB_DATABASE_NAME: identity
+      ASPNETCORE_ENVIRONMENT: Development
 
   notesnook-server:
     image: streetwriters/notesnook-sync:latest
@@ -173,6 +174,7 @@ services:
       S3_SERVICE_URL: "${ATTACHMENTS_SERVER_PUBLIC_URL}"
       S3_REGION: "us-east-1"
       S3_BUCKET_NAME: "attachments"
+      ASPNETCORE_ENVIRONMENT: Development
 
   sse-server:
     image: streetwriters/sse:latest
@@ -192,6 +194,7 @@ services:
       start_period: 60s
     environment:
       <<: *server-discovery
+      ASPNETCORE_ENVIRONMENT: Development
 
   monograph-server:
     image: streetwriters/monograph:latest


### PR DESCRIPTION
## Summary
- set ASPNETCORE_ENVIRONMENT to Development for identity-server
- set ASPNETCORE_ENVIRONMENT to Development for notesnook-server
- set ASPNETCORE_ENVIRONMENT to Development for sse-server

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1a3eab4a88332959b5ca138e01c6a